### PR TITLE
Reverse ordering of hexdigest (fixes #2)

### DIFF
--- a/lib/objecthash.rb
+++ b/lib/objecthash.rb
@@ -43,7 +43,7 @@ class ObjectHash
 
   # Compute the ObjectHash of the given object as hexadecimal
   def hexdigest(object)
-    digest(object).unpack("h*").first
+    digest(object).unpack("H*").first
   end
 
   private


### PR DESCRIPTION
Was previously incorrectly using low nibble-first instead of high nibble-first ordering (ala Digest::*#hexdigest)
