### PR TITLE
Add Unicode string normalization option (on by default). Pull test vectors from benlaurie/objecthash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
   DisplayCopNames: true
   Exclude:
     - '**/*.pb.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 bundler_args: --without development doc
 
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
   - 2.3.1
   - jruby-9.1.1.0

--- a/README.md
+++ b/README.md
@@ -38,11 +38,17 @@ set of types. The following types are supported:
 
 The `#digest` and `#hexdigest` methods are available on ObjectHash:
 
+Please note that Strings have [Unicode normalization](http://ruby-doc.org/stdlib-2.2.0/libdoc/unicode_normalize/rdoc/String.html) applied to them by default.
+You can disable this if desired by passing in the `normalize: false` keyword
+argument to `#digest` or `#hexdigest`.
+
 ```ruby
 >> ObjectHash.hexdigest("Hello, Ruby!")
-=> "9c72561c53e0d66f08d0abedbd43023f895d3f7c3ea8d34aa8da3b3322088ff5"
+=> "c92765c1350e6df6800dbadedb3420f398d5f3c7e38a3da48aadb3332280f85f"
+>> ObjectHash.hexdigest("Hello, Ruby!", normalize: false)
+=> "c92765c1350e6df6800dbadedb3420f398d5f3c7e38a3da48aadb3332280f85f"
 >> ObjectHash.hexdigest([{complex: "structures"}, {can: "be"}, {hashed: ["with", "ObjectHash"]}])
-=> "81177799cd12ff8fb4030a56847043c836b27c94c8e5040c526a1cb8a962662d"
+=> "18717799dc21fff84b30a0654807348c632bc7498c5e40c025a6c18b9a2666d2"
 ```
 
 Additionally you can provide a different hash algorithm by instantiating a class:
@@ -51,7 +57,7 @@ Additionally you can provide a different hash algorithm by instantiating a class
 >> objecthash = ObjectHash.new(Digest::SHA512)
 => #<ObjectHash:0x007ffdf39765f0 @hash_algorithm=Digest::SHA512>
 >> objecthash.hexdigest("")
-=> "85009711fbf96617e16fe508b7623c692a6dbf64f4341825c0d5a475d5bb1815f0973de543694021a877a1fca211a7a2dfde0c218db3e08b2266a8eed0fe7474"
+=> "58007911bf9f66711ef65e807b26c396a2d6fb464f4381520c5d4a575dbb81510f79d35e349604128a771acf2a117a2afdedc012d83b0eb822668aee0def4747"
 ```
 
 For compatibility reasons it's recommended you use the default hash algorithm (SHA-256).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The `#digest` and `#hexdigest` methods are available on ObjectHash:
 
 Please note that Strings have [Unicode normalization](http://ruby-doc.org/stdlib-2.2.0/libdoc/unicode_normalize/rdoc/String.html) applied to them by default.
 You can disable this if desired by passing in the `normalize: false` keyword
-argument to `#digest` or `#hexdigest`.
+argument to `#digest` or `#hexdigest`. `String#unicode_normalize` was added in
+MRI Ruby v2.2.0 and that is the minimum supported version for ObjectHash.
 
 ```ruby
 >> ObjectHash.hexdigest("Hello, Ruby!")

--- a/lib/objecthash.rb
+++ b/lib/objecthash.rb
@@ -43,7 +43,7 @@ class ObjectHash
 
   # Compute the ObjectHash of the given object as hexadecimal
   def hexdigest(object)
-    digest(object).unpack("h*").first
+    digest(object).unpack("H*").first
   end
 
   private

--- a/lib/objecthash.rb
+++ b/lib/objecthash.rb
@@ -12,13 +12,13 @@ class ObjectHash
   DEFAULT_HASH_ALGORITHM = Digest::SHA256
 
   # Compute a raw ObjectHash digest using the default algorithm
-  def self.digest(object)
-    new.digest(object)
+  def self.digest(object, normalize: true)
+    new.digest(object, normalize: normalize)
   end
 
   # Compute an hex ObjectHash digest using the default algorithm
-  def self.hexdigest(object)
-    new.hexdigest(object)
+  def self.hexdigest(object, normalize: true)
+    new.hexdigest(object, normalize: normalize)
   end
 
   def initialize(hash_algorithm = DEFAULT_HASH_ALGORITHM)
@@ -26,12 +26,12 @@ class ObjectHash
   end
 
   # Compute the ObjectHash of the given object
-  def digest(object)
+  def digest(object, normalize: true)
     case object
     when Array       then obj_hash_list(object)
     when Hash        then obj_hash_dict(object)
-    when String      then obj_hash_unicode(object)
-    when Symbol      then obj_hash_unicode(object.to_s)
+    when String      then obj_hash_unicode(object, normalize)
+    when Symbol      then obj_hash_unicode(object.to_s, normalize)
     when Float       then obj_hash_float(object)
     when Fixnum      then obj_hash_int(object)
     when Set         then obj_hash_set(object)
@@ -42,8 +42,8 @@ class ObjectHash
   end
 
   # Compute the ObjectHash of the given object as hexadecimal
-  def hexdigest(object)
-    digest(object).unpack("H*").first
+  def hexdigest(object, normalize: true)
+    digest(object, normalize: normalize).unpack("H*").first
   end
 
   private
@@ -69,8 +69,12 @@ class ObjectHash
     hash_primitive("d", h)
   end
 
-  def obj_hash_unicode(u)
-    hash_primitive("u", u.encode("utf-8"))
+  # Takes a unicode string and a boolean to indicate
+  # whether to normalize unicode or not.
+  def obj_hash_unicode(u, n)
+    u_enc = u.encode("utf-8")
+    u_norm = n ? u_enc.unicode_normalize(:nfc) : u_enc
+    hash_primitive("u", u_norm)
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/objecthash.gemspec
+++ b/objecthash.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
     works cross-language, and, therefore, cross-encoding.
   DESCRIPTION
 
+  spec.required_ruby_version = ">= 2.2.0"
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/spec/objecthash_spec.rb
+++ b/spec/objecthash_spec.rb
@@ -1,63 +1,183 @@
 require "spec_helper"
 
+# rubocop:disable Metrics/LineLength
+# rubocop:disable Style/WordArray
+# rubocop:disable Style/NumericLiterals
+
 RSpec.describe ObjectHash do
   it "has a version number" do
     expect(described_class::VERSION).not_to be nil
   end
 
+  context "benlaurie/objecthash specs" do
+    context "normalization of unicode strings" do
+      it "calculates matching digests" do
+        u1n = "\u03d3"
+        u1d = "\u03d2\u0301"
+        expect(u1n).to_not eq u1d
+        n1n = described_class.digest(u1n)
+        n1d = described_class.digest(u1d)
+        expect(n1n).to eq n1d
+      end
+
+      it "calculates matching hexdigests" do
+        u1n = "\u03d3"
+        u1d = "\u03d2\u0301"
+        expect(u1n).to_not eq u1d
+        n1n = described_class.hexdigest(u1n)
+        n1d = described_class.hexdigest(u1d)
+        expect(n1n).to eq n1d
+      end
+
+      it "calculates matching hexdigests for strings in an Array" do
+        u1n = "\u03d3"
+        u1d = "\u03d2\u0301"
+        l1n1 = [u1n]
+        l1n2 = [u1n, u1n]
+        l1d = [u1n, u1d]
+        expect(l1n1).to_not eq l1n2
+        expect(l1n1).to_not eq l1d
+        expect(l1n2).to_not eq l1d
+
+        nl1n1 = described_class.hexdigest(l1n1)
+        nl1n2 = described_class.hexdigest(l1n2)
+        nl1d = described_class.hexdigest(l1d)
+
+        expect(nl1n1).to_not eq nl1n2
+        expect(nl1n1).to_not eq nl1d
+        expect(nl1n2).to eq nl1d
+      end
+
+      it "calculates the same hexdigest hash for a JSON list" do
+        expect(described_class.hexdigest(JSON.parse('["foo", "bar"]'))).to eq "32ae896c413cfdc79eec68be9139c86ded8b279238467c216cf2bec4d5f1e4a2"
+      end
+
+      it "calculates the same hexdigest hash with normalization true" do
+        expect(described_class.hexdigest("\u03d3")).to eq "f72826713a01881404f34975447bd6edcb8de40b191dc57097ebf4f5417a554d"
+        expect(described_class.hexdigest("\u03d2\u0301")).to eq "f72826713a01881404f34975447bd6edcb8de40b191dc57097ebf4f5417a554d"
+      end
+
+      it "calculates a different hexdigest hash with normalization false" do
+        expect(described_class.hexdigest("\u03d2\u0301", normalize: false)).to eq "42d5b13fb064849a988a86eb7650a22881c0a9ecf77057a1b07ab0dad385889c"
+      end
+    end
+
+    # extracted from : https://github.com/benlaurie/objecthash/blob/master/common_json.test
+    context "common json" do
+      it "calculates known hashes with Arrays of strings" do
+        expect(described_class.hexdigest([])).to eq "acac86c0e609ca906f632b0e2dacccb2b77d22b0621f20ebece1a4835b93f6f0"
+        expect(described_class.hexdigest(["foo"])).to eq "268bc27d4974d9d576222e4cdbb8f7c6bd6791894098645a19eeca9c102d0964"
+        expect(described_class.hexdigest(["foo", "bar"])).to eq "32ae896c413cfdc79eec68be9139c86ded8b279238467c216cf2bec4d5f1e4a2"
+      end
+
+      # FIXME : failing with a different hash than those found here:
+      # https://github.com/benlaurie/objecthash/blob/master/common_json.test#L12
+      xit "calculates known hashes with Arrays of Integers" do
+        expect(described_class.hexdigest([123])).to eq "2e72db006266ed9cdaa353aa22b9213e8a3c69c838349437c06896b1b34cee36"
+        expect(described_class.hexdigest([1, 2, 3])).to eq "925d474ac71f6e8cb35dd951d123944f7cabc5cda9a043cf38cd638cc0158db0"
+        expect(described_class.hexdigest([123456789012345])).to eq "f446de5475e2f24c0a2b0cd87350927f0a2870d1bb9cbaa794e789806e4c0836"
+        expect(described_class.hexdigest([123456789012345, 678901234567890])).to eq "d4cca471f1c68f62fbc815b88effa7e52e79d110419a7c64c1ebb107b07f7f56"
+      end
+
+      it "calculates known hashes with Objects with (lists of) Strings" do
+        expect(described_class.hexdigest(JSON.parse("{}"))).to eq "18ac3e7343f016890c510e93f935261169d9e3f565436429830faf0934f4f8e4"
+        expect(described_class.hexdigest(JSON.parse('{"foo": "bar"}'))).to eq "7ef5237c3027d6c58100afadf37796b3d351025cf28038280147d42fdc53b960"
+        expect(described_class.hexdigest(JSON.parse('{"foo": ["bar", "baz"], "qux": ["norf"]}'))).to eq "f1a9389f27558538a064f3cc250f8686a0cebb85f1cab7f4d4dcc416ceda3c92"
+      end
+
+      it "calculates known hashes with Array of nil value" do
+        expect(described_class.hexdigest([nil])).to eq "5fb858ed3ef4275e64c2d5c44b77534181f7722b7765288e76924ce2f9f7f7db"
+      end
+
+      it "calculates known hashes with Booleans" do
+        expect(described_class.hexdigest(true)).to eq "7dc96f776c8423e57a2785489a3f9c43fb6e756876d6ad9a9cac4aa4e72ec193"
+        expect(described_class.hexdigest(false)).to eq "c02c0b965e023abee808f2b548d8d5193a8b5229be6f3121a6f16e2d41a449b3"
+      end
+
+      # FIXME : FAILS ON FLOAT NORMALIZE
+      xit "calculates known hashes with Floating point numbers" do
+        expect(described_class.hexdigest(1.2345)).to eq "844e08b1195a93563db4e5d4faa59759ba0e0397caf065f3b6bc0825499754e0"
+        expect(described_class.hexdigest(-10.1234)).to eq "59b49ae24998519925833e3ff56727e5d4868aba4ecf4c53653638ebff53c366"
+      end
+
+      # FIXME : FAILS ON FLOAT NORMALIZE
+      xit "calculates known hashes with a mixture of all types" do
+        expect(described_class.hexdigest(JSON.parse('["foo", {"bar": ["baz", null, 1.0, 1.5, 0.0001, 1000.0, 2.0, -23.1234, 2.0]}]'))).to eq "783a423b094307bcb28d005bc2f026ff44204442ef3513585e7e73b66e3c2213"
+      end
+
+      # FIXME : FAILS ON FLOAT NORMALIZE
+      xit "calculates known hashes with a mixture of Integers and Floats which are the same in common JSON" do
+        expect(described_class.hexdigest(JSON.parse('["foo", {"bar": ["baz", null, 1, 1.5, 0.0001, 1000, 2, -23.1234, 2]}]'))).to eq "783a423b094307bcb28d005bc2f026ff44204442ef3513585e7e73b66e3c2213"
+      end
+
+      # FIXME : FAILS ON FLOAT NORMALIZE
+      xit "calculates known hashes when changing just a key name" do
+        expect(described_class.hexdigest(JSON.parse('["foo", {"b4r": ["baz", null, 1, 1.5, 0.0001, 1000, 2, -23.1234, 2]}]'))).to eq "7e01f8b45da35386e4f9531ff1678147a215b8d2b1d047e690fd9ade6151e431"
+      end
+
+      it "order independence" do
+        expect(described_class.hexdigest(JSON.parse('{"k1": "v1", "k2": "v2", "k3": "v3"}'))).to eq "ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057"
+        expect(described_class.hexdigest(JSON.parse('{"k2": "v2", "k1": "v1", "k3": "v3"}'))).to eq "ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057"
+      end
+
+      it "unicode" do
+        expect(described_class.hexdigest("ԱԲաբ")).to eq "2a2a4485a4e338d8df683971956b1090d2f5d33955a81ecaad1a75125f7a316c"
+        expect(described_class.hexdigest("\u03d3")).to eq "f72826713a01881404f34975447bd6edcb8de40b191dc57097ebf4f5417a554d"
+        # Note that this is the same character as above, but hashes
+        # differently unless unicode normalisation is applied
+        expect(described_class.hexdigest("\u03d2\u0301", normalize: false)).to eq "42d5b13fb064849a988a86eb7650a22881c0a9ecf77057a1b07ab0dad385889c"
+        expect(described_class.hexdigest("\u03d2\u0301", normalize: true)).to eq "f72826713a01881404f34975447bd6edcb8de40b191dc57097ebf4f5417a554d"
+      end
+    end
+  end
+
   context "booleans" do
     it "calculates the hash of true" do
-      expect(described_class.hexdigest(true)).to eq "d79cf677c648325ea7725884a9f3c934bfe65786676ddaa9c9caa44a7ee21c39"
+      expect(described_class.hexdigest(true)).to eq "7dc96f776c8423e57a2785489a3f9c43fb6e756876d6ad9a9cac4aa4e72ec193"
     end
 
     it "calculates the hash of false" do
-      expect(described_class.hexdigest(false)).to eq "0cc2b069e520a3eb8e802f5b848d5d91a3b82592ebf613126a1fe6d2144a943b"
+      expect(described_class.hexdigest(false)).to eq "c02c0b965e023abee808f2b548d8d5193a8b5229be6f3121a6f16e2d41a449b3"
     end
 
     it "calculates the hash of nil" do
-      expect(described_class.hexdigest(nil)).to eq "b1611bfd35b81ad23c9fe7bd8bc5aa07054dc641184392f0be8af028638cd39b"
+      expect(described_class.hexdigest(nil)).to eq "1b16b1df538ba12dc3f97edbb85caa7050d46c148134290feba80f8236c83db9"
     end
   end
 
   context "lists" do
     it "calculates the hash of an empty Array" do
-      expect(described_class.hexdigest([])).to eq "caca680c6e90ac09f636b2e0d2cacc2b7bd7220b26f102bece1e4a38b5396f0f"
+      expect(described_class.hexdigest([])).to eq "acac86c0e609ca906f632b0e2dacccb2b77d22b0621f20ebece1a4835b93f6f0"
     end
   end
 
   context "dicts" do
     it "calculates the hash of an empty Hash" do
-      expect(described_class.hexdigest({})).to eq "81cae337340f6198c015e0399f536211969d3e5f5634469238f0fa90434f8f4e"
+      expect(described_class.hexdigest({})).to eq "18ac3e7343f016890c510e93f935261169d9e3f565436429830faf0934f4f8e4"
     end
   end
 
   context "sets" do
     it "calculates the hash of an empty Set" do
-      expect(described_class.hexdigest(Set.new)).to eq "40a31778475c27dba852daeb1bfbdcc52065ea11ecfcf9c9f329d5e025ebfa98"
-    end
-  end
-
-  context "unicode strings" do
-    it "calculates the hash of an empty String" do
-      expect(described_class.hexdigest("")).to eq "b0ef39e5073c127caca3cf57ecd0c02a9fb845220e80bb130cc0d6f7f1c1a06d"
+      expect(described_class.hexdigest(Set.new)).to eq "043a718774c572bd8a25adbeb1bfcd5c0256ae11cecf9f9c3f925d0e52beaf89"
     end
   end
 
   context "symbols" do
     it "calculates the hash of an empty Smybol" do
-      expect(described_class.hexdigest(:"")).to eq "b0ef39e5073c127caca3cf57ecd0c02a9fb845220e80bb130cc0d6f7f1c1a06d"
+      expect(described_class.hexdigest(:"")).to eq "0bfe935e70c321c7ca3afc75ce0d0ca2f98b5422e008bb31c00c6d7f1f1c0ad6"
     end
   end
 
   context "integers" do
     it "calculates the hash of 0" do
-      expect(described_class.hexdigest(0)).to eq "4a1e767aa650da8d8a56c461b9700b44a7190653ea6f20fd01e3a80eeff23f09"
+      expect(described_class.hexdigest(0)).to eq "a4e167a76a05add8a8654c169b07b0447a916035aef602df103e8ae0fe2ff390"
     end
   end
 
   context "floats" do
     it "calculates the hash of 0.0" do
-      expect(described_class.hexdigest(0.0)).to eq "0601d1c8c99b881441863e989075f153d7aa76fb5f7a0b3a9fea92c54dba3ad3"
+      expect(described_class.hexdigest(0.0)).to eq "60101d8c9cb988411468e38909571f357daa67bff5a7b0a3f9ae295cd4aba33d"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "json"
 require "objecthash"
 
 RSpec.configure(&:disable_monkey_patching!)


### PR DESCRIPTION
See issue #2 

Add Unicode string normalization option (on by default). Pull test vectors from benlaurie/objecthash

Some of the test vectors are not currently working. They are marked with Rspec `xit` to
temporarily disable them but show them in test runs.

All of the existing hexdigest values in docs and specs changed as a result of the
bugfix for issue #2

Added docs to README to show how to turn Unicode normalization off if desired.
